### PR TITLE
Feature/add custom deployment host support

### DIFF
--- a/id/id/src/main/java/io/piano/android/id/PianoId.kt
+++ b/id/id/src/main/java/io/piano/android/id/PianoId.kt
@@ -73,7 +73,7 @@ class PianoId {
                     .baseUrl(endpoint)
                     .addConverterFactory(MoshiConverterFactory.create(moshi))
                     .build()
-                PianoIdClient(retrofit.create(), moshi, aid, endpoint).also { client = it }
+                PianoIdClient(retrofit.create(), moshi, aid, endpoint, useCustomDeploymentHost).also { client = it }
             }
 
         /**

--- a/id/id/src/main/java/io/piano/android/id/PianoId.kt
+++ b/id/id/src/main/java/io/piano/android/id/PianoId.kt
@@ -32,22 +32,24 @@ class PianoId {
          * @param endpoint Endpoint, which will be used. For example, {@link #ENDPOINT_PRODUCTION},
          *                 {@link #ENDPOINT_SANDBOX} or your custom endpoint
          * @param aid      Your AID
+         * @param useCustomDeploymentHost a flag if a custom deployment host should be used ([endpoint] will be used as is)
          * @return {@link PianoIdClient} instance.
          */
         @Suppress("unused") // Public API.
         @JvmStatic
-        fun init(endpoint: String, aid: String): PianoIdClient = init(endpoint.toHttpUrl(), aid)
+        fun init(endpoint: String, aid: String, useCustomDeploymentHost: Boolean = false): PianoIdClient = init(endpoint.toHttpUrl(), aid, useCustomDeploymentHost)
 
         /**
          * Initialize {@link PianoIdClient} singleton instance. It doesn't re-init it at next calls.
          *
          * @param endpoint Endpoint, which will be used.
          * @param aid      Your AID
+         * @param useCustomDeploymentHost If true [endpoint] will be used as deployment host else (default) the host gets overridden internally.
          * @return {@link PianoIdClient} instance.
          */
         @Suppress("unused") // Public API.
         @JvmStatic
-        fun init(endpoint: HttpUrl, aid: String): PianoIdClient =
+        fun init(endpoint: HttpUrl, aid: String, useCustomDeploymentHost: Boolean = false): PianoIdClient =
             client ?: run {
                 val userAgent = "Piano ID SDK ${BuildConfig.SDK_VERSION} (Android ${Build.VERSION.RELEASE})"
                 val okHttpClient = OkHttpClient.Builder()

--- a/id/id/src/main/java/io/piano/android/id/PianoId.kt
+++ b/id/id/src/main/java/io/piano/android/id/PianoId.kt
@@ -32,24 +32,24 @@ class PianoId {
          * @param endpoint Endpoint, which will be used. For example, {@link #ENDPOINT_PRODUCTION},
          *                 {@link #ENDPOINT_SANDBOX} or your custom endpoint
          * @param aid      Your AID
-         * @param useCustomDeploymentHost a flag if a custom deployment host should be used ([endpoint] will be used as is)
+         * @param useCustomHost a flag if a custom deployment host should be used ([endpoint] will be used as is)
          * @return {@link PianoIdClient} instance.
          */
         @Suppress("unused") // Public API.
         @JvmStatic
-        fun init(endpoint: String, aid: String, useCustomDeploymentHost: Boolean = false): PianoIdClient = init(endpoint.toHttpUrl(), aid, useCustomDeploymentHost)
+        fun init(endpoint: String, aid: String, useCustomHost: Boolean = false): PianoIdClient = init(endpoint.toHttpUrl(), aid, useCustomHost)
 
         /**
          * Initialize {@link PianoIdClient} singleton instance. It doesn't re-init it at next calls.
          *
          * @param endpoint Endpoint, which will be used.
          * @param aid      Your AID
-         * @param useCustomDeploymentHost If true [endpoint] will be used as deployment host else (default) the host gets overridden internally.
+         * @param useCustomHost If true [endpoint] will be used as deployment host else (default) the host gets overridden internally.
          * @return {@link PianoIdClient} instance.
          */
         @Suppress("unused") // Public API.
         @JvmStatic
-        fun init(endpoint: HttpUrl, aid: String, useCustomDeploymentHost: Boolean = false): PianoIdClient =
+        fun init(endpoint: HttpUrl, aid: String, useCustomHost: Boolean = false): PianoIdClient =
             client ?: run {
                 val userAgent = "Piano ID SDK ${BuildConfig.SDK_VERSION} (Android ${Build.VERSION.RELEASE})"
                 val okHttpClient = OkHttpClient.Builder()
@@ -73,7 +73,7 @@ class PianoId {
                     .baseUrl(endpoint)
                     .addConverterFactory(MoshiConverterFactory.create(moshi))
                     .build()
-                PianoIdClient(retrofit.create(), moshi, aid, endpoint, useCustomDeploymentHost).also { client = it }
+                PianoIdClient(retrofit.create(), moshi, aid, endpoint, useCustomHost).also { client = it }
             }
 
         /**

--- a/id/id/src/main/java/io/piano/android/id/PianoIdClient.kt
+++ b/id/id/src/main/java/io/piano/android/id/PianoIdClient.kt
@@ -33,6 +33,7 @@ class PianoIdClient internal constructor(
     private val moshi: Moshi,
     internal val aid: String,
     endpoint: HttpUrl,
+    useCustomDeploymentHost: Boolean
 ) {
     private val pianoIdTokenAdapter by lazy {
         moshi.adapter(PianoIdToken::class.java)
@@ -55,7 +56,9 @@ class PianoIdClient internal constructor(
     var javascriptInterface: PianoIdJs? = null
 
     init {
-        loadHostUrl()
+        if (!useCustomDeploymentHost) {
+            loadHostUrl()
+        }
     }
 
     /**

--- a/id/id/src/main/java/io/piano/android/id/PianoIdClient.kt
+++ b/id/id/src/main/java/io/piano/android/id/PianoIdClient.kt
@@ -33,7 +33,7 @@ class PianoIdClient internal constructor(
     private val moshi: Moshi,
     internal val aid: String,
     endpoint: HttpUrl,
-    useCustomDeploymentHost: Boolean
+    useCustomHost: Boolean
 ) {
     private val pianoIdTokenAdapter by lazy {
         moshi.adapter(PianoIdToken::class.java)
@@ -56,7 +56,7 @@ class PianoIdClient internal constructor(
     var javascriptInterface: PianoIdJs? = null
 
     init {
-        if (!useCustomDeploymentHost) {
+        if (!useCustomHost) {
             loadHostUrl()
         }
     }


### PR DESCRIPTION
Add `useCustomHost` flag to avoid overriding the passed endpoint in the `PianoIdClient`. 