### PR TITLE
Allow changing js interface name

### DIFF
--- a/composer-show-template/README.md
+++ b/composer-show-template/README.md
@@ -21,8 +21,24 @@ Add code into your show template listener
 Kotlin
 ```kotlin
 // Use one of these
-ShowTemplateController(showTemplateEvent, customJavascriptInterface).show(activity)
-ShowTemplateController(showTemplateEvent, customJavascriptInterface).show(activity, inlineWebViewProvider)
+ShowTemplateController(showTemplateEvent, deviceIdProvider, customJavascriptInterface).show(activity)
+ShowTemplateController(showTemplateEvent, deviceIdProvider, customJavascriptInterface).show(activity, inlineWebViewProvider)
+```
+
+`customJavascriptInterface` is optional; when omitted a default `ComposerJs` instance is used.
+
+#### Custom JavaScript interface name
+
+By default the JavaScript interface is exposed to the template under the name `PianoAndroid`.
+If you need a different name, pass an optional `jsInterfaceName` argument:
+
+```kotlin
+ShowTemplateController(
+    showTemplateEvent,
+    deviceIdProvider,
+    customJavascriptInterface,
+    jsInterfaceName = "MyCustomName",
+).show(activity)
 ```
 
 ## How to show templates inline

--- a/composer-show-template/api/composer-show-template.api
+++ b/composer-show-template/api/composer-show-template.api
@@ -12,8 +12,8 @@ public class io/piano/android/composer/showtemplate/ComposerJs : io/piano/androi
 }
 
 public final class io/piano/android/composer/showtemplate/ShowTemplateController : io/piano/android/showhelper/BaseShowController {
-	public fun <init> (Lio/piano/android/composer/model/Event;Lio/piano/android/common/DeviceIdProvider;Lio/piano/android/composer/showtemplate/ComposerJs;)V
-	public synthetic fun <init> (Lio/piano/android/composer/model/Event;Lio/piano/android/common/DeviceIdProvider;Lio/piano/android/composer/showtemplate/ComposerJs;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/piano/android/composer/model/Event;Lio/piano/android/common/DeviceIdProvider;Lio/piano/android/composer/showtemplate/ComposerJs;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/piano/android/composer/model/Event;Lio/piano/android/common/DeviceIdProvider;Lio/piano/android/composer/showtemplate/ComposerJs;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun close (Ljava/lang/String;)V
 	public final fun reloadWithToken (Ljava/lang/String;)V
 }

--- a/composer-show-template/api/composer-show-template.api
+++ b/composer-show-template/api/composer-show-template.api
@@ -20,7 +20,8 @@ public final class io/piano/android/composer/showtemplate/ShowTemplateController
 
 public final class io/piano/android/composer/showtemplate/ShowTemplateDialogFragment : io/piano/android/showhelper/BaseShowDialogFragment {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun onCancel (Landroid/content/DialogInterface;)V
 }
 

--- a/composer-show-template/src/main/java/io/piano/android/composer/showtemplate/ShowTemplateController.kt
+++ b/composer-show-template/src/main/java/io/piano/android/composer/showtemplate/ShowTemplateController.kt
@@ -25,11 +25,14 @@ import io.piano.android.showhelper.BaseShowController
  * @param jsInterface The optional [ComposerJs] JavaScript interface for communication with the
  *                    displayed template. If not provided, a default instance of [ComposerJs] will
  *                    be used.
+ * @param jsInterfaceName The optional name under which the JavaScript interface is exposed to the
+ *                        template. If not provided, defaults to [JAVASCRIPT_INTERFACE].
  */
 public class ShowTemplateController(
     event: Event<ShowTemplate>,
     deviceIdProvider: DeviceIdProvider,
     jsInterface: ComposerJs? = null,
+    private val jsInterfaceName: String = JAVASCRIPT_INTERFACE,
 ) : BaseShowController<ShowTemplate, ComposerJs>(event.eventData, jsInterface ?: ComposerJs()) {
     // Private properties
     private val trackingId = event.eventExecutionContext.trackingId
@@ -43,7 +46,7 @@ public class ShowTemplateController(
         ShowTemplateDialogFragment(url, trackingId, additionalHttpHeaders)
     }
 
-    override fun WebView.configure(): Unit = prepare(null, jsInterface, trackingId)
+    override fun WebView.configure(): Unit = prepare(null, jsInterface, trackingId, jsInterfaceName)
 
     override fun processDelay(activity: FragmentActivity, showFunction: () -> Unit) {
         val func: () -> Unit = {
@@ -87,7 +90,7 @@ public class ShowTemplateController(
 
     internal companion object {
         private const val FRAGMENT_TAG = "ShowTemplateDialogFragment"
-        private const val JAVASCRIPT_INTERFACE = "PianoAndroid"
+        internal const val JAVASCRIPT_INTERFACE = "PianoAndroid"
 
         // Internal function for WebView preparation
         @SuppressLint("SetJavaScriptEnabled")
@@ -95,11 +98,12 @@ public class ShowTemplateController(
             dialogFragment: ShowTemplateDialogFragment? = null,
             javascriptInterface: ComposerJs?,
             trackingId: String,
+            jsInterfaceName: String = JAVASCRIPT_INTERFACE,
         ) {
             settings.javaScriptEnabled = true
             val jsInterface = javascriptInterface ?: ComposerJs()
             jsInterface.init(dialogFragment, this, trackingId)
-            addJavascriptInterface(jsInterface, JAVASCRIPT_INTERFACE)
+            addJavascriptInterface(jsInterface, jsInterfaceName)
         }
     }
 }

--- a/composer-show-template/src/main/java/io/piano/android/composer/showtemplate/ShowTemplateController.kt
+++ b/composer-show-template/src/main/java/io/piano/android/composer/showtemplate/ShowTemplateController.kt
@@ -43,7 +43,7 @@ public class ShowTemplateController(
         mapOf(DeviceIdProvider.DEVICE_ID_HEADER to deviceIdProvider.deviceId)
     override val fragmentTag: String = FRAGMENT_TAG
     override val fragmentProvider: () -> ShowTemplateDialogFragment = {
-        ShowTemplateDialogFragment(url, trackingId, additionalHttpHeaders)
+        ShowTemplateDialogFragment(url, trackingId, additionalHttpHeaders, jsInterfaceName)
     }
 
     override fun WebView.configure(): Unit = prepare(null, jsInterface, trackingId, jsInterfaceName)

--- a/composer-show-template/src/main/java/io/piano/android/composer/showtemplate/ShowTemplateDialogFragment.kt
+++ b/composer-show-template/src/main/java/io/piano/android/composer/showtemplate/ShowTemplateDialogFragment.kt
@@ -3,6 +3,7 @@ package io.piano.android.composer.showtemplate
 import android.content.DialogInterface
 import android.os.Bundle
 import android.webkit.WebView
+import io.piano.android.composer.showtemplate.ShowTemplateController.Companion.JAVASCRIPT_INTERFACE
 import io.piano.android.composer.showtemplate.ShowTemplateController.Companion.prepare
 import io.piano.android.showhelper.BaseJsInterface
 import io.piano.android.showhelper.BaseShowDialogFragment
@@ -29,21 +30,29 @@ public class ShowTemplateDialogFragment : BaseShowDialogFragment {
      * @param url The URL of the Piano Composer template to be displayed.
      * @param trackingId The tracking ID associated with the template.
      * @param additionalHttpHeaders Additional HTTP headers for loading the URL
+     * @param jsInterfaceName The name under which the JavaScript interface is exposed to the template.
      */
     public constructor(
         url: String,
         trackingId: String,
         additionalHttpHeaders: Map<String, String>,
+        jsInterfaceName: String = JAVASCRIPT_INTERFACE,
     ) : super(url, additionalHttpHeaders) {
         val args = arguments ?: Bundle()
         arguments = args.apply {
             putString(KEY_TRACKING_ID, trackingId)
+            putString(KEY_JS_INTERFACE_NAME, jsInterfaceName)
         }
     }
 
     /** The tracking ID associated with the template. */
     private val trackingId: String by lazy {
         arguments?.getString(KEY_TRACKING_ID) ?: ""
+    }
+
+    /** The name under which the JavaScript interface is exposed to the template. */
+    private val jsInterfaceName: String by lazy {
+        arguments?.getString(KEY_JS_INTERFACE_NAME) ?: JAVASCRIPT_INTERFACE
     }
 
     /**
@@ -55,7 +64,7 @@ public class ShowTemplateDialogFragment : BaseShowDialogFragment {
      * @param jsInterface The JavaScript interface used for communication with the template.
      */
     override fun WebView.configure(jsInterface: BaseJsInterface?): Unit =
-        prepare(this@ShowTemplateDialogFragment, jsInterface as? ComposerJs, trackingId)
+        prepare(this@ShowTemplateDialogFragment, jsInterface as? ComposerJs, trackingId, jsInterfaceName)
 
     /**
      * Called when the dialog is canceled.
@@ -76,5 +85,6 @@ public class ShowTemplateDialogFragment : BaseShowDialogFragment {
      */
     private companion object {
         private const val KEY_TRACKING_ID = "trackingId"
+        private const val KEY_JS_INTERFACE_NAME = "jsInterfaceName"
     }
 }


### PR DESCRIPTION
We would like to be able to have the JavaScript interface between native app code and logic inside the template at `window.Android` instead of `window.PianoAndroid`. This PR would make that possible (with existing integrations of the SDK in mind). See also support ticket [#885660](https://support.piano.io/hc/requests/885660)